### PR TITLE
PHP 5.4 improvements for Debug Objects

### DIFF
--- a/debug_objects.php
+++ b/debug_objects.php
@@ -83,6 +83,10 @@ if ( ! class_exists( 'Debug_Objects' ) ) {
 			register_deactivation_hook( __FILE__, array( $this, 'on_deactivation' ) );
 			register_uninstall_hook( __FILE__,    array( 'Debug_Objects', 'on_deactivation' ) );
 			
+			// Include PHP 5.4 specific code improvements
+			if ( version_compare( phpversion(), '5.4.0', '>=' ) ) {
+				require_once dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'inc/php-54-improvements.php';
+			}
 			// include for load safe mode
 			require_once dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'inc/class-default_mode.php';
 			// Include settings

--- a/inc/class-query.php
+++ b/inc/class-query.php
@@ -412,22 +412,13 @@ if ( ! class_exists( 'Debug_Objects_Query' ) ) {
 
 				$debug_queries .= '<hr /><ol>' . "\n";
 				
-				/*
-				// for php 5.3 and higher
-				if ( version_compare( phpversion(), '5.4.0', '>=' ) ) {
-					// sort queries from high to low
-					// use time value in first subquery, array value 1
-					if ( ! empty( $sorting ) || ! $sorting )
-						usort( $this->_queries, $this->make_comparer( [1, $sorting] ) );
-				} else {
-				*/
+				$this->_queries = apply_filters( 'debug_objects_sort_queries', $this->_queries, $sorting );
 				
-					foreach ( $this->_queries as $key => $row ) {
-    					$queries[$key]  = $row[0]; 
-						// of course, replace 0 with whatever is the date field's index
-					}
-					array_multisort( $queries, $sorting, $this->_queries );
-				//}
+				foreach ( $this->_queries as $key => $row ) {
+    				$queries[$key]  = $row[0]; 
+					// of course, replace 0 with whatever is the date field's index
+				}
+				array_multisort( $queries, $sorting, $this->_queries );
 				
 				foreach ( $this->_queries as $q ) {
 					

--- a/inc/php-54-improvements.php
+++ b/inc/php-54-improvements.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Adding PHP 5.4.x specific improvements for the Debug Objects capabilities
+ *
+ * @since 2.1.16
+ * @author nofearinc
+ *
+ */
+class Debug_Objects_Php54 {
+	
+	/**
+	 * Add all required filters/actions
+	 */
+	public function __construct() {
+		add_filter( 'debug_objects_sort_queries', array( $this, 'sort_queries' ), 10, 2 );
+	}
+	
+	/**
+	 * Sort queries for the class-query listing if PHP 5.4 is active (using shorthand for arrays)
+	 *
+	 * @param array $queries WP_Query array
+	 * @param int|false $sorting
+	 * @return array $queries sorted queries list
+	 */
+	public function sort_queries( $queries, $sorting ) {
+		if ( ! empty( $sorting ) || ! $sorting )
+			usort( $queries, Debug_Objects_Query->make_comparer( [1, $sorting] ) );
+
+		return $queries;
+	}
+}
+
+new Debug_Objects_Php54();


### PR DESCRIPTION
This PR suggest adding a separate class for PHP 5.4 specific improvements, since a functionality is already implemented for higher PHP versions than the minimum requirements for WordPress.

Adding the new class would be included only if the current versions is higher than 5.4.
