### PR TITLE
Prevent missing post index notice when switching themes

### DIFF
--- a/inc/class-rewrite_backtrace.php
+++ b/inc/class-rewrite_backtrace.php
@@ -62,7 +62,7 @@ class Debug_Objects_Rewrite_Backtrace {
 		$output['debug_backtrace'] = ob_get_contents();
 		$output['_get']            = $_GET;
 		$output['_post']           = $_POST;
-		$output['global_post']     = $GLOBALS['post'];
+		$output['global_post']     = isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : '';
 		if ( is_network_admin() )
 			set_site_transient( $this->transient_string, $output, 120 );
 		else


### PR DESCRIPTION
Found that accidentally while switching themes testing some Core functionality. My error log spit:

```
[Tue Sep 17 00:58:42 2013] [error] [client 127.0.0.1] PHP Notice:  Undefined index: post in /opt/lampp/htdocs/wpbleeding/wp-content/plugins/Debug-Objects/inc/class-rewrite_backtrace.php on line 65, referer: http://localhost/wpbleeding/wp-admin/themes.php?activated=true
[Tue Sep 17 00:58:42 2013] [error] [client 127.0.0.1] PHP Stack trace:, referer: http://localhost/wpbleeding/wp-admin/themes.php?activated=true
[Tue Sep 17 00:58:42 2013] [error] [client 127.0.0.1] PHP   1. {main}() /opt/lampp/htdocs/wpbleeding/wp-admin/themes.php:0, referer: http://localhost/wpbleeding/wp-admin/themes.php?activated=true
[Tue Sep 17 00:58:42 2013] [error] [client 127.0.0.1] PHP   2. wp_redirect() /opt/lampp/htdocs/wpbleeding/wp-admin/themes.php:24, referer: http://localhost/wpbleeding/wp-admin/themes.php?activated=true
[Tue Sep 17 00:58:42 2013] [error] [client 127.0.0.1] PHP   3. apply_filters() /opt/lampp/htdocs/wpbleeding/wp-includes/pluggable.php:881, referer: http://localhost/wpbleeding/wp-admin/themes.php?activated=true
[Tue Sep 17 00:58:42 2013] [error] [client 127.0.0.1] PHP   4. call_user_func_array() /opt/lampp/htdocs/wpbleeding/wp-includes/plugin.php:173, referer: http://localhost/wpbleeding/wp-admin/themes.php?activated=true
[Tue Sep 17 00:58:42 2013] [error] [client 127.0.0.1] PHP   5. Debug_Objects_Rewrite_Backtrace->redirect_debug() /opt/lampp/htdocs/wpbleeding/wp-includes/plugin.php:173, referer: http://localhost/wpbleeding/wp-admin/themes.php?activated=true
```

I didn't find where this variable is used in the first place, but browsed for a bit and got no more error_log notices. If it isn't used at all, I can just remove that line (or change the default value to something else).
